### PR TITLE
Implement rom size as input parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+*.exe
+*.d
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 #define LOG_PAGE_SIZE       256
 
 //16k
-#define MAX_SIZE 4*4*1024
+#define MAX_SIZE 48*4*1024
 
 #define FILEDIR "files"
 #define ROMNAME "spiff_rom.bin"
@@ -17,7 +17,7 @@ static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
 static u8_t spiffs_fds[32*4];
 static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE+32)*4];
 
-#define S_DBG
+#define S_DBG /*printf*/
 
 FILE *rom;
 
@@ -170,10 +170,10 @@ void add_file(char* fname) {
     sprintf(path,"%s/%s", FILEDIR,fname);
 
 
-    FILE *fp = fopen(path,"r");
+    FILE *fp = fopen(path,"rb");
 
     if (fp == NULL){
-        S_DBG("Skipping %s",path);
+        S_DBG("Skipping %s\n",path);
         return;
     }
 

--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -180,7 +180,7 @@ typedef struct {
   u32_t fd_count;
 
   // last error
-  s32_t errno;
+  s32_t myerrno;
 
   // current number of free blocks
   u32_t free_blocks;

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -101,7 +101,7 @@ void ICACHE_FLASH_ATTR SPIFFS_unmount(spiffs *fs) {
 }
 
 s32_t ICACHE_FLASH_ATTR SPIFFS_errno(spiffs *fs) {
-  return fs->errno;
+  return fs->myerrno;
 }
 
 s32_t ICACHE_FLASH_ATTR SPIFFS_creat(spiffs *fs, const char *path, spiffs_mode mode) {
@@ -542,7 +542,7 @@ static s32_t ICACHE_FLASH_ATTR spiffs_fflush_cache(spiffs *fs, spiffs_file fh) {
           spiffs_get_cache_page(fs, spiffs_get_cache(fs), fd->cache_page->ix),
           fd->cache_page->offset, fd->cache_page->size);
       if (res < SPIFFS_OK) {
-        fs->errno = res;
+        fs->myerrno = res;
       }
       spiffs_cache_fd_release(fs, fd->cache_page);
     }
@@ -567,7 +567,7 @@ s32_t ICACHE_FLASH_ATTR SPIFFS_fflush(spiffs *fs, spiffs_file fh) {
 
 void ICACHE_FLASH_ATTR SPIFFS_close(spiffs *fs, spiffs_file fh) {
   if (!SPIFFS_CHECK_MOUNT(fs)) {
-    fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    fs->myerrno = SPIFFS_ERR_NOT_MOUNTED;
     return;
   }
   SPIFFS_LOCK(fs);
@@ -582,7 +582,7 @@ void ICACHE_FLASH_ATTR SPIFFS_close(spiffs *fs, spiffs_file fh) {
 
 spiffs_DIR *ICACHE_FLASH_ATTR SPIFFS_opendir(spiffs *fs, const char *name, spiffs_DIR *d) {
   if (!SPIFFS_CHECK_MOUNT(fs)) {
-    fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    fs->myerrno = SPIFFS_ERR_NOT_MOUNTED;
     return 0;
   }
   d->fs = fs;
@@ -626,7 +626,7 @@ static s32_t ICACHE_FLASH_ATTR spiffs_read_dir_v(
 
 struct spiffs_dirent *ICACHE_FLASH_ATTR SPIFFS_readdir(spiffs_DIR *d, struct spiffs_dirent *e) {
   if (!SPIFFS_CHECK_MOUNT(d->fs)) {
-    d->fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    d->fs->myerrno = SPIFFS_ERR_NOT_MOUNTED;
     return 0;
   }
   SPIFFS_LOCK(fs);
@@ -651,7 +651,7 @@ struct spiffs_dirent *ICACHE_FLASH_ATTR SPIFFS_readdir(spiffs_DIR *d, struct spi
     d->entry = entry + 1;
     ret = e;
   } else {
-    d->fs->errno = res;
+    d->fs->myerrno = res;
   }
   SPIFFS_UNLOCK(fs);
   return ret;
@@ -778,7 +778,7 @@ s32_t ICACHE_FLASH_ATTR SPIFFS_vis(spiffs *fs) {
   } // per block
 
   spiffs_printf("era_cnt_max: %i\n", fs->max_erase_count);
-  spiffs_printf("last_errno:  %i\n", fs->errno);
+  spiffs_printf("last_errno:  %i\n", fs->myerrno);
   spiffs_printf("blocks:      %i\n", fs->block_count);
   spiffs_printf("free_blocks: %i\n", fs->free_blocks);
   spiffs_printf("page_alloc:  %i\n", fs->stats_p_allocated);

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -247,19 +247,19 @@
 
 #define SPIFFS_API_CHECK_MOUNT(fs) \
   if (!SPIFFS_CHECK_MOUNT((fs))) { \
-    (fs)->errno = SPIFFS_ERR_NOT_MOUNTED; \
+    (fs)->myerrno = SPIFFS_ERR_NOT_MOUNTED; \
     return -1; \
   }
 
 #define SPIFFS_API_CHECK_RES(fs, res) \
   if ((res) < SPIFFS_OK) { \
-    (fs)->errno = (res); \
+    (fs)->myerrno = (res); \
     return -1; \
   }
 
 #define SPIFFS_API_CHECK_RES_UNLOCK(fs, res) \
   if ((res) < SPIFFS_OK) { \
-    (fs)->errno = (res); \
+    (fs)->myerrno = (res); \
     SPIFFS_UNLOCK(fs); \
     return -1; \
   }


### PR DESCRIPTION
- Implement rom size as input param: this controls how much flash is used for storing fs
- Replace errno to fix windows compile err: windows complains using errno, says it's a function
- Modify fopen param from r to rb; file read failed on my system by using "r" without the binary open mode
